### PR TITLE
ページ全体の設定を追加

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -2,3 +2,8 @@
  *= require_tree .
  *= require_self
  */
+ .base-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1rem;
+  }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>GyakutenCloneGroup</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -10,6 +11,15 @@
   </head>
 
   <body>
-    <%= yield %>
+    <header>
+    </header>
+    <main>
+      <div class="base-container">
+        <%= yield %>
+      </div>
+    </main>
+    <footer>
+
+    </footer>
   </body>
 </html>


### PR DESCRIPTION
## 実装内容

原則，マークダウン記法のリストで記載すること

- ページ全体（app/views/layouts/application.html.erb）の設定を追加
  - mainタグに"base-container"を設定
  - スマホ用にビューポートを設定

- CSS記載（app/assets/stylesheets/application.css）
  - "base-container"のCSS記載

## 参考資料
https://developers.google.com/web/fundamentals/design-and-ux/responsive?hl=ja#set-the-viewport

## チェックリスト

- [x] GitHub で Files changed を確認


