### PR TITLE
17_AWSテキスト教材詳細ページの実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,8 @@ gem 'webpacker', '~> 4.0'
 gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.7'
 gem 'bootsnap', '>= 1.4.2', require: false
+gem 'redcarpet'
+gem 'coderay'
 gem 'devise-bootstrap-views'
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,6 +155,7 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    redcarpet (3.5.0)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
@@ -211,6 +212,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
+  coderay
   devise
   devise-bootstrap-views
   devise-i18n
@@ -223,6 +225,7 @@ DEPENDENCIES
   puma (~> 4.1)
   rails (~> 6.0.3)
   rails-i18n (~> 6.0)
+  redcarpet
   sass-rails (>= 6)
   spring
   spring-watcher-listen (~> 2.0.0)

--- a/app/controllers/aws_texts_controller.rb
+++ b/app/controllers/aws_texts_controller.rb
@@ -2,4 +2,9 @@ class AwsTextsController < ApplicationController
   def index
     @aws_texts=AwsText.all
   end
+
+  def show
+    @aws_text=AwsText.
+  end
+
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,48 @@
 module ApplicationHelper
-end
+  require "redcarpet"
+  require "coderay"
+
+  class HTMLwithCoderay < Redcarpet::Render::HTML
+    def block_code(code, language)
+            language = language.split(':')[0] if language.present?
+
+            case language.to_s
+            when 'rb'
+                lang = :ruby
+            when 'yml'
+                lang = :yaml
+            when 'css'
+                lang = :css
+            when 'html'
+                lang = :html
+            when ''
+                lang = :md
+            else
+                lang = language
+            end
+
+            CodeRay.scan(code, lang).div
+        end
+    end
+
+    def markdown(text)
+        html_render = HTMLwithCoderay.new(
+          filter_html: true,
+          hard_wrap: true,
+          link_attributes: { rel: 'nofollow', target: "_blank" }
+        )
+        options = {
+            autolink: true,
+            space_after_headers: true,
+            no_intra_emphasis: true,
+            fenced_code_blocks: true,
+            tables: true,
+            hard_wrap: true,
+            xhtml: true,
+            lax_html_blocks: true,
+            strikethrough: true
+        }
+        markdown = Redcarpet::Markdown.new(html_render, options)
+        markdown.render(text).html_safe
+    end
+  end

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -14,8 +14,6 @@ body {
   padding-top: 56px;
 }
 
-
- 
 // ヘッダー
 .nav-item {
   font-size: small;

--- a/app/views/aws_texts/index.html.erb
+++ b/app/views/aws_texts/index.html.erb
@@ -1,6 +1,6 @@
 <h1 class="text-center">AWS講座</h1>
 <p>注意！！！：AWSのEC2やRDSは有料サービスとなります。無駄な料金を請求されないためにも、不要なインスタンスは停止・削除をしてください。</p>
-<table class="table">
+<table class="table table-striped">
   <thead class="bg-primary text-white">
     <tr>
       <th scope="col">NO.</th>
@@ -11,7 +11,7 @@
     <% @aws_texts.each_with_index do |aws_text,i|%>
       <tr>
         <th scope="row"><%= i+1 %></th>
-        <td><%= aws_text.title %></td>
+        <td><%= link_to aws_text.title, aws_text %></td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/aws_texts/show.html.erb
+++ b/app/views/aws_texts/show.html.erb
@@ -1,0 +1,3 @@
+<p>
+  <%= markdown(@aws_text.content) %>
+</p>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -16,15 +16,15 @@ ActiveRecord::Schema.define(version: 2020_10_16_090829) do
   enable_extension "plpgsql"
 
   create_table "aws_texts", force: :cascade do |t|
-    t.string "title"
-    t.text "content"
+    t.string "title", null: false
+    t.text "content", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "movies", force: :cascade do |t|
-    t.string "title"
-    t.string "url"
+    t.string "title", null: false
+    t.string "url", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
## 実装内容
- Markdown導入
- AWSテキスト教材一覧ページから詳細ページへ移動できるよう修正
  - 但し、リンクは貼れたものの、詳細ページにてcontentが表示できない状態

## 参考資料
- Markdownの導入
  - [RailsアプリへのMarkdownの導入](https://arcane-gorge-21903.herokuapp.com/texts/224)

## チェックリスト
- [ ] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット（必要があれば）
<img width="1440" alt="スクリーンショット 2020-10-19 23 33 53" src="https://user-images.githubusercontent.com/69391730/96465640-26af8a00-1264-11eb-9ce9-10af7f8d2ce5.png">




