### PR TITLE
20-2_【質問集】質問一覧表示機能の実装

### DIFF
--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,6 +1,7 @@
 class QuestionsController < ApplicationController
   def index
     @question = Question.new
+    @questions = Question.order(id: :desc)
   end
 
   def show
@@ -23,6 +24,10 @@ class QuestionsController < ApplicationController
 
   private
   
+  def set_question
+    @question = Question.find(params[:id])  
+  end
+
   def question_params
     params.require(:question).permit(:title, :detail)
   end

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -13,15 +13,6 @@ class QuestionsController < ApplicationController
     redirect_to question, notice: "質問を投稿しました"
   end
 
-  def edit
-  end
-
-  def update
-  end
-
-  def destroy
-  end
-
   private
   
   def set_question

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -1,11 +1,14 @@
 class QuestionsController < ApplicationController
+
+  before_action :set_question, only: %i[show edit update destroy]
+
   def index
     @question = Question.new
     @questions = Question.order(id: :desc)
   end
 
   def show
-    @question = Question.find(params[:id])
+
   end
 
   def create

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,9 +13,9 @@
   <body>
     <header>
       <%= render "layouts/header" %>
-      <%= render "layouts/flash" %>
     </header>
     <main>
+      <%= render "layouts/flash" %>
       <div class="base-container">
         <%= yield %>
       </div>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -3,12 +3,12 @@
 <%= form_with model: @question, local: true do |form| %>
 <%# 質問フォーム %>
   <div class="form-group">
-    <%= form.label "【質問】" %>
+    <%= form.label :title, "【質問】" %>
     <%= form.text_area :title, class: "form-control" %>
   </div>
 <%# 詳細フォーム %>
   <div class="form-group">
-    <%= form.label "【詳細】" %>
+    <%= form.label :detail, "【詳細】" %>
     <%= form.text_area :detail, class: "form-control" %>
   </div>
 <%# 送信ボタン %>

--- a/app/views/questions/index.html.erb
+++ b/app/views/questions/index.html.erb
@@ -1,14 +1,32 @@
 <h2>新規投稿</h2>
+
 <%= form_with model: @question, local: true do |form| %>
-  <div>
-    <%= form.label :title, "【質問】" %><br>
-    <%= form.text_field :title %>
+<%# 質問フォーム %>
+  <div class="form-group">
+    <%= form.label "【質問】" %>
+    <%= form.text_area :title, class: "form-control" %>
   </div>
-  <div>
-    <%= form.label :detail, "【詳細】" %><br>
-    <%= form.text_field :detail %>
+<%# 詳細フォーム %>
+  <div class="form-group">
+    <%= form.label "【詳細】" %>
+    <%= form.text_area :detail, class: "form-control" %>
   </div>
+<%# 送信ボタン %>
   <div>
-    <%= form.submit "送信" %>
+    <%= form.submit "送信", class: "btn btn-primary btn-block" %>
   </div>
 <% end %>
+
+
+<%# 質問一覧を降順表示 %>
+<table>
+  <tbody>
+    <% @questions.each.with_index(1) do |question, i| %>
+      <tr>
+        <td>
+        <button type="button" class="btn btn-outline-light btn-lg btn-block"><%= link_to question.title, question %></button>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>


### PR DESCRIPTION
## 実装内容

- ビュー`index`の上部に質問投稿フォームを設置
- ビュー`index`質問投稿フォーム下部に質問一覧をタイトル毎に降順表示
- 投稿フォーム及び一覧表示する各質問にBootstrapを適用

## 参考資料

- [メッセージ投稿アプリ（その3・Bootstrap）
](https://arcane-gorge-21903.herokuapp.com/texts/271)
- Bootstrap(公式)
  - [Buttons](https://getbootstrap.jp/docs/4.5/components/buttons/)

## チェックリスト

- [x] GitHub で Files changed を確認
- [x] 影響し得る範囲のローカル環境での動作確認
