### PR TITLE
Feature/read through 管理者画面にrubyを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,3 +71,10 @@ yarn-debug.log*
 /storage/*
 !/storage/.keep
 /public/uploads
+
+/public/packs
+/public/packs-test
+/node_modules
+/yarn-error.log
+yarn-debug.log*
+.yarn-integrity

--- a/app/admin/ruby.rb
+++ b/app/admin/ruby.rb
@@ -1,0 +1,3 @@
+ActiveAdmin.register Ruby do
+  permit_params :title, :content
+end

--- a/app/models/ruby.rb
+++ b/app/models/ruby.rb
@@ -1,0 +1,3 @@
+class Ruby < ApplicationRecord
+  validates :title, :content, presence: true
+end

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,9 +1,3 @@
 const { environment } = require('@rails/webpacker')
 
-const webpack = require('webpack')
-environment.plugins.append('Provide', new webpack.ProvidePlugin({
-    $: 'jquery',
-    jQuery: 'jquery'
-}))
-
 module.exports = environment

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_22_125313) do
+ActiveRecord::Schema.define(version: 2020_10_31_000619) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -55,6 +55,14 @@ ActiveRecord::Schema.define(version: 2020_10_22_125313) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "posts", force: :cascade do |t|
+    t.string "content", null: false
+    t.bigint "user_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
   create_table "questions", force: :cascade do |t|
     t.string "title"
     t.text "detail"
@@ -74,4 +82,5 @@ ActiveRecord::Schema.define(version: 2020_10_22_125313) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "posts", "users"
 end

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@rails/actioncable": "^6.0.0",
     "@rails/activestorage": "^6.0.0",
     "@rails/ujs": "^6.0.0",
-    "@rails/webpacker": "4.2.2",
+    "@rails/webpacker": "4.3.0",
     "bootstrap": "^4.5.3",
     "jquery": "^3.5.1",
     "popper.js": "^1.16.1",
@@ -14,6 +14,6 @@
   },
   "version": "0.1.0",
   "devDependencies": {
-    "webpack-dev-server": "^3.10.3"
+    "webpack-dev-server": "^3.11.0"
   }
 }


### PR DESCRIPTION
## 実装内容

- 管理者画面にruby教材の投稿画面を追加したい
  - admin/ruby.rbを追加
  - models/ruby.rbを追加

## 参考資料

- モデルの関連付け その2
  - https://arcane-gorge-21903.herokuapp.com/texts/297

## チェックリスト

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット（必要があれば）


## 備考
読破ボタン実装のためのテキスト教材を用意しようと試みています。見本のようにruby/railsの教材内（最下部）にボタンを設置したいので、先ず、管理者画面にruby/railsのテキスト教材を投稿できる画面を作成しようと考えました。

