### PR TITLE
読破済みボタンをボタン化

### DIFF
--- a/app/views/aws_texts/_disread_text.html.erb
+++ b/app/views/aws_texts/_disread_text.html.erb
@@ -1,1 +1,3 @@
-<%= link_to "読破済みにする", aws_text_read_texts_path(aws_text), method: :post, remote: true %>
+<a class="btn btn-secondary btn-block" data-remote="true" rel="nofollow" data-method="post" href="/aws_texts/1/read_texts">読破済みにする</a>
+
+<%# <%= link_to "読破済みにする", aws_text_read_texts_path(aws_text), method: :post, remote: true %> 

--- a/app/views/aws_texts/_disread_text.html.erb
+++ b/app/views/aws_texts/_disread_text.html.erb
@@ -1,3 +1,2 @@
-<a class="btn btn-secondary btn-block" data-remote="true" rel="nofollow" data-method="post" href="aws_texts/aws_text_read_texts_path(aws_text)">読破済みにする</a>
+<%= link_to "読破済みにする", aws_text_read_texts_path(aws_text), class: "btn btn-secondary btn-block", method: :post, remote: true %>
 
-<%# <%= link_to "読破済みにする", aws_text_read_texts_path(aws_text), method: :post, remote: true %> 

--- a/app/views/aws_texts/_disread_text.html.erb
+++ b/app/views/aws_texts/_disread_text.html.erb
@@ -1,3 +1,3 @@
-<a class="btn btn-secondary btn-block" data-remote="true" rel="nofollow" data-method="post" href="/aws_texts/1/read_texts">読破済みにする</a>
+<a class="btn btn-secondary btn-block" data-remote="true" rel="nofollow" data-method="post" href="aws_texts/aws_text_read_texts_path(aws_text)">読破済みにする</a>
 
 <%# <%= link_to "読破済みにする", aws_text_read_texts_path(aws_text), method: :post, remote: true %> 

--- a/app/views/aws_texts/_read_text.html.erb
+++ b/app/views/aws_texts/_read_text.html.erb
@@ -1,1 +1,2 @@
-<%= link_to "読破ずみを解除する", aws_text_read_texts_path(aws_text), method: :delete, remote: true %>
+<a class="btn btn-secondary btn-block" data-remote="true" rel="nofollow" data-method="delete" href="/aws_texts/1/read_texts">読破ずみを解除する</a>
+<%# <%= link_to "読破ずみを解除する", aws_text_read_texts_path(aws_text), method: :delete, remote: true %>

--- a/app/views/aws_texts/_read_text.html.erb
+++ b/app/views/aws_texts/_read_text.html.erb
@@ -1,2 +1,2 @@
-<a class="btn btn-secondary btn-block" data-remote="true" rel="nofollow" data-method="delete" href="/aws_texts/1/read_texts">読破ずみを解除する</a>
+<a class="btn btn-secondary btn-block" data-remote="true" rel="nofollow" data-method="delete" href="aws_texts/aws_text_read_texts_path(aws_text)">読破ずみを解除する</a>
 <%# <%= link_to "読破ずみを解除する", aws_text_read_texts_path(aws_text), method: :delete, remote: true %>

--- a/app/views/aws_texts/_read_text.html.erb
+++ b/app/views/aws_texts/_read_text.html.erb
@@ -1,2 +1,1 @@
-<a class="btn btn-secondary btn-block" data-remote="true" rel="nofollow" data-method="delete" href="aws_texts/aws_text_read_texts_path(aws_text)">読破ずみを解除する</a>
-<%# <%= link_to "読破ずみを解除する", aws_text_read_texts_path(aws_text), method: :delete, remote: true %>
+<%= link_to "読破ずみを解除する", aws_text_read_texts_path(aws_text), class: "btn btn-secondary btn-block", method: :delete, remote: true %>


### PR DESCRIPTION
## 実装内容

原則，マークダウン記法のリストで記載すること

- bootstrapを用いて読破ボタンをボタン化
  - 読破済みにする及び読破済みを解除するをボタン化

## 参考資料

マークダウン記法のリンクを用いて記載すること

- bootstrap
  - [bootstrap教材その１](https://arcane-gorge-21903.herokuapp.com/texts/260)

## チェックリスト

- [ ] GitHub で Files changed を確認
- [ ] 影響し得る範囲のローカル環境での動作確認

## スクリーンショット（必要があれば）


## 備考
bootstrapでボタン化を行いました。（あくまでも見た目の変更だけ）
ただ、cssをいじっていないので、hover時のカーソル化やクリック後の色の変更などは行えていません。
ご確認お願い致します！

